### PR TITLE
Add mypy.ini

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,25 @@
+[mypy]
+strict_optional = True
+warn_no_return = True
+warn_unused_configs = True
+warn_unused_ignores = True
+warn_redundant_casts = True
+no_implicit_optional = True
+
+[not-yet-mypy]
+disallow_subclassing_any = True
+disallow_untyped_defs = True
+disallow_any_generics = True
+disallow_any_unimported = True
+
+[mypy-Foundation.*]
+ignore_missing_imports = True
+
+[mypy-UserNotifications.*]
+ignore_missing_imports = True
+
+[mypy-AppKit.*]
+ignore_missing_imports = True
+
+[mypy-PyObjCTools.*]
+ignore_missing_imports = True


### PR DESCRIPTION
This config enables some hardening that already passes fine on 0.910, while
leaving out some other nice things to enable later.

Most importantly, it silences errors about pyobjc imports not containing type
hints.