### PR TITLE
exec the mac app

### DIFF
--- a/runme
+++ b/runme
@@ -5,4 +5,4 @@ rm -fr ./build ./dist;
 # https://github.com/ronaldoussoren/py2app/issues/444
 python setup.py py2app --alias | cat;
 rm -fr ./build;
-./dist/Pomodouroboros.app/Contents/MacOS/Pomodouroboros;
+exec ./dist/Pomodouroboros.app/Contents/MacOS/Pomodouroboros

--- a/runme
+++ b/runme
@@ -5,4 +5,4 @@ rm -fr ./build ./dist;
 # https://github.com/ronaldoussoren/py2app/issues/444
 python setup.py py2app --alias | cat;
 rm -fr ./build;
-exec ./dist/Pomodouroboros.app/Contents/MacOS/Pomodouroboros
+exec ./dist/Pomodouroboros.app/Contents/MacOS/Pomodouroboros;


### PR DESCRIPTION
This way, if the app hangs, `kill -9 %1` does the right thing. Otherwise, killing runme causes the app to run forever in the background and requires hunting it down.