### PR TITLE
Drop unnecessary `wheel` from build deps

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,6 @@
 [build-system]
 requires = [
   "setuptools>=42",
-  "wheel",
 ]
 build-backend = "setuptools.build_meta"
 


### PR DESCRIPTION
This was never needed, but some docs used to show it in examples in the past. I corrected that in the `setuptools`' docs a while back. Older `setuptools` used to depend on this project via a PEP 517 hook when building wheels, while the modern versions vendor it now (since a little over a year ago).